### PR TITLE
modified Ashe to do dry runs on multiple threads.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: '6.7.0.202309050840-r'
     implementation group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
     implementation 'org.plumelib:plume-util:1.9.0'
+    implementation 'commons-io:commons-io:2.18.0'
 
     checkerFramework "org.checkerframework:checker:${checkerFrameworkVersion}"
 }


### PR DESCRIPTION
Ashe will now do dry runs in parallel. I had to add an apache library to gradle to make copying files easier.
This ought to speed up CI runs for specimin by a good margin.
I solved issues with data races by giving each thread an independant copy of the cloned repository to work with.
If any of my notes for this should be placed in the Specimin repo as well let me know.